### PR TITLE
Add NFData instance for TimeZoneSeries

### DIFF
--- a/Data/Time/LocalTime/TimeZone/Series.hs
+++ b/Data/Time/LocalTime/TimeZone/Series.hs
@@ -34,6 +34,7 @@ import Data.List (partition)
 import Data.Maybe (listToMaybe, fromMaybe)
 import Data.Typeable (Typeable)
 import Control.Arrow (first)
+import Control.DeepSeq (NFData(..))
 
 -- Conditional import, depending on whether time library is pre-1.6 or
 -- post-1.6, controlled by cabal flag:
@@ -79,6 +80,9 @@ instance Show TimeZoneSeries where
 
 instance Read TimeZoneSeries where
     readsPrec n = map (first $ flip TimeZoneSeries []) . readsPrec n
+
+instance NFData TimeZoneSeries where
+  rnf tzs = rnf (tzsTimeZone tzs, tzsTransitions tzs)
 
 instance ParseTime TimeZoneSeries where
   buildTime locale = mapBuiltTime (flip TimeZoneSeries []) . buildTime locale

--- a/timezone-series.cabal
+++ b/timezone-series.cabal
@@ -40,6 +40,7 @@ Library
   Other-modules:       Data.Time.LocalTime.TimeZone.Internal.MapBuiltTime
   Default-extensions:  DeriveDataTypeable
   Build-depends:       base >= 4.4 && < 5
+                     , deepseq
   if flag(time_pre_1_6)
     Build-depends:     time >= 1.1.4 && < 1.6
   else


### PR DESCRIPTION
All underlying pieces of TimeZoneSeries specify NFData instances. Anything containing a TimeZoneSeries and requiring an NFData instance is forced to either derive generics or create an orphan instance, which is less than ideal. Allowing this instance will make TimeZoneSeries more versatile.