### PR TITLE
Get working with time 1.8

### DIFF
--- a/Data/Time/LocalTime/TimeZone/Series.hs
+++ b/Data/Time/LocalTime/TimeZone/Series.hs
@@ -1,6 +1,7 @@
 -- | A @TimeZoneSeries@ describes a timezone by specifying the various
 -- clock settings that occurred in the past and are scheduled to occur
 -- in the future for the timezone.
+{-# LANGUAGE CPP #-}
 
 module Data.Time.LocalTime.TimeZone.Series
 (
@@ -93,7 +94,11 @@ latestNonSummer (TimeZoneSeries d cs) = fromMaybe d . listToMaybe $
 
 instance FormatTime TimeZoneSeries where
   formatCharacter = 
+#if MIN_VERSION_time(1,8,0)
+    fmap (\f locale mpado mwidth -> f locale mpado mwidth . latestNonSummer) .
+#else
     fmap (\f locale mpado -> f locale mpado . latestNonSummer) .
+#endif
     formatCharacter
 
 -- | Given a timezone represented by a @TimeZoneSeries@, and a @UTCTime@,
@@ -175,7 +180,11 @@ instance ParseTime ZoneSeriesTime where
 
 instance FormatTime ZoneSeriesTime where
   formatCharacter =
+#if MIN_VERSION_time(1,8,0)
+    fmap (\f locale mpado mwidth -> f locale mpado mwidth . zoneSeriesTimeToZonedTime) .
+#else
     fmap (\f locale mpado -> f locale mpado . zoneSeriesTimeToZonedTime) .
+#endif
     formatCharacter
 
 -- | The @ZonedTime@ of a @ZoneSeriesTime@.

--- a/timezone-series.cabal
+++ b/timezone-series.cabal
@@ -43,4 +43,4 @@ Library
   if flag(time_pre_1_6)
     Build-depends:     time >= 1.1.4 && < 1.6
   else
-    Build-depends:     time >= 1.6 && < 1.7
+    Build-depends:     time >= 1.6 && < 1.9


### PR DESCRIPTION
`time-1.8.*` features an extra parameter corresponding to a width (`Maybe Int`) in the `formatCharacter` method of `FormatTime`.

This PR passes that parameter (it is relatively transparent, and as it is an instance should not break any downstream packages… hopefully).

I have introduced conditional compilation for the relevant module using `{#- LANGUAGE CPP -#}` to ensure the library compiles correctly on the 1.6 and 1.8 branches of `time`.