### PR TITLE
Allow time 1.10, 1.11, 1.12, 1.13

### DIFF
--- a/timezone-series.cabal
+++ b/timezone-series.cabal
@@ -33,4 +33,4 @@ Library
   Default-extensions:  DeriveDataTypeable
   Build-depends:       base >= 4.4 && < 5
                      , deepseq
-                     , time (>= 1.1.4 && < 1.9) || (>= 1.9.1 && < 1.10)
+                     , time (>= 1.1.4 && < 1.9) || (>= 1.9.1 && < 1.14)


### PR DESCRIPTION
~~I have only tested with time 1.11, because I am not sure how to test with the other versions (is there some kind of Cabal-install flag to do it?).~~ Tested using `cabal build --constraint='time==1.10'` for all versions up to 1.13. 1.13 was withdrawn so it doesn't build, but that is expected. This way, the next time it is bumped, we will know that 1.13 was already tested.

This would help me a great deal for using the library on GHC 9.2.

Note that even a Hackage revision would resolve this problem.