### PR TITLE
bump time upper bound

### DIFF
--- a/timezone-series.cabal
+++ b/timezone-series.cabal
@@ -1,5 +1,5 @@
 Name:                timezone-series
-Version:             0.1.13
+Version:             0.1.14
 Synopsis:            Enhanced timezone handling for Data.Time
 Description:         This package endows Data.Time, from the time
                      package, with several data types and functions
@@ -32,4 +32,4 @@ Library
   Default-extensions:  DeriveDataTypeable
   Build-depends:       base >= 4.4 && < 5
                      , deepseq
-                     , time (>= 1.1.4 && < 1.9) || (>= 1.9.1 && < 1.14)
+                     , time (>= 1.1.4 && < 1.9) || (>= 1.9.1 && < 1.15)


### PR DESCRIPTION
this allows for ghc 9.12 compatibility on stackage